### PR TITLE
Support for strange keys like: George Martin06

### DIFF
--- a/lib/bibtex/lexer.rb
+++ b/lib/bibtex/lexer.rb
@@ -149,8 +149,8 @@ module BibTeX
 				push([:COMMA,','])
 			when @scanner.scan(/\d+/o)
 				push([:NUMBER,@scanner.matched])
-			when @scanner.scan(/[a-z\d\/:_!$\.%&*-]+/io)
-				push([:NAME,@scanner.matched])
+			when @scanner.scan(/[a-z\d \/:_!$\.%&*-]+/io)
+				push([:NAME,@scanner.matched.rstrip])
 			when @scanner.scan(/"/o)
 				@mode = :literal
 			when @scanner.scan(/#/o)

--- a/test/bibtex/test_parser.rb
+++ b/test/bibtex/test_parser.rb
@@ -21,6 +21,13 @@ module BibTeX
         assert_equal %w{ key:0 key:1 foo }.map(&:to_sym), @bib.map(&:key)
       end
 
+      should 'handle strange keys' do
+        input = "@Misc{George Martin06,title = {FEAST FOR CROWS}}"
+        bib = Parser.new(:debug => false, :strict => false).parse(input)
+        assert_equal :"George Martin06", bib.first.key
+        assert bib[:"George Martin06"]
+      end
+
       should 'parse the entry types' do
         assert_equal [:book, :article, :article], @bib.map(&:type)
       end


### PR DESCRIPTION
Hi,

I got a bibtex file exported from some kind of book-collection software (I think Delicious Library 2) that contained a strange item:

@Misc{george martin06,
    ISBN = {0006486126},
    keywords = {Textbook Buyback, Paperback, Printed Books},
    year = {2006},
    author = {GEORGE R.R. MARTIN},
    title = {FEAST FOR CROWS},
    pages = {976},
    edition = {New Ed},
    language = {English (Unknown), English (Original Language), English (Published)},
    number = {0},
    publisher = {Bantam}
}

I tried to find proper BibTeX specification to see if such a value (george martin06) is allowed for the key but couldn't find one, so I've just adjusted your parser to handle it, because the previous behaviour just choked on the item and didn't return any of the other items in the file.

I'm not sure what should the correct behaviour be in such a case, so if you have another idea let me know, I might be able to adjust the patch.

Cheers,
Wojtek
