### PR TITLE
multi_json is now a runtime dependency.

### DIFF
--- a/bibtex-ruby.gemspec
+++ b/bibtex-ruby.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 	END_DESCRIPTION
 	
   s.add_runtime_dependency('latex-decode', ['>=0.0.3'])
-  s.add_development_dependency('multi_json', ['~>1.0'])
+  s.add_runtime_dependency('multi_json', ['~>1.0'])
 
   s.add_development_dependency('rake', ['~>0.9'])
   s.add_development_dependency('racc', ['~>1.4'])


### PR DESCRIPTION
See
https://github.com/inukshuk/bibtex-ruby/commit/c6d770b053e26dc0a37d56d80b58ea2ceb912370
