### PR TITLE
Fixes a bug where Entry#dup would not return exact copies

### DIFF
--- a/lib/bibtex/entry.rb
+++ b/lib/bibtex/entry.rb
@@ -335,13 +335,10 @@ module BibTeX
     # add(:author, "Edgar A. Poe", :title, "The Raven")
     # add([:author, "Edgar A. Poe", :title, "The Raven"])
     # add(:author => "Edgar A. Poe", :title => "The Raven")
+    # add(:author => Names.new(Name.new(:first => 'Edgar A.', :last => 'Poe')))
     def add(*arguments)
       Hash[*arguments.flatten].each_pair do |name, value|
-        if value.class < Value
-          fields[name.to_sym] = value
-        else
-          fields[name.to_sym] = Value.new(value)
-        end
+        fields[name.to_sym] = Value.create(value)
       end
       
       self

--- a/lib/bibtex/value.rb
+++ b/lib/bibtex/value.rb
@@ -55,6 +55,16 @@ module BibTeX
     def_delegators :to_s, :=~, :===, *String.instance_methods(false).reject { |m| m =~ /^\W|^length$|^dup$|!$/ }
     def_delegators :@tokens, :[], :length
     def_delegator :@tokens, :each, :each_token
+
+    # call-seq:
+    #   create(other) => other.dup
+    #   create(*args) => Value.new(args)
+    #
+    # Duplicates a +Value+ object (or an object of any subclass of +Value+),
+    # or initializes a new one.
+    def self.create(*args)
+      args[0].class < Value && args.size == 1 ? args[0].dup : Value.new(args)
+    end
     
     def initialize(*arguments)
       @tokens = []

--- a/test/bibtex/test_entry.rb
+++ b/test/bibtex/test_entry.rb
@@ -14,7 +14,7 @@ module BibTeX
     describe '#add' do
       it 'preserves BibTeX::Names (and other subclasses of BibTeX::Value)' do
         e = Entry.new
-        e.add(:author, Names.new(Name.new(first: 'Limperg')))
+        e.add(:author, Names.new(Name.new(:first => 'first_name')))
         assert_equal e[:author].class, Names
       end
     end

--- a/test/bibtex/test_value.rb
+++ b/test/bibtex/test_value.rb
@@ -2,6 +2,20 @@ require 'helper.rb'
 
 module BibTeX
   class ValueTest < MiniTest::Spec
+
+    describe "::create" do
+      it "should return a duplicate when called with a Value subclass" do
+        val   = Value.new('value')
+        names = Names.new(Name.new(:first => 'first_name'))
+
+        assert_equal val.dup,   Value.create(val)
+        assert_equal names.dup, Value.create(names)
+      end
+
+      it "should return a new Value object when called with other arguments" do
+        assert_equal Value.new('value'), Value.create('value')
+      end
+    end
     
     describe "when empty" do
       it "should be equal to an empty string" do


### PR DESCRIPTION
Entry#initialize_copy uses Entry#add to duplicate fields, which was
problematic because #add turned every argument into a `Value` object. Most
notably, `Names` objects were converted into `Value`s as well, losing
their extra functionality.

Hence, Entry#dup returned objects that didn't behave as their 'clones'
in certain situations, which it should not.

In order to resolve this problem, Entry#add now checks if its arguments
are subclasses of Value, in which case it adds them to Entry#fields
directly. That way, at least bibtex-ruby's standard classes are
preserved. It might also be appropriate, however, to drop #add from
Entry#initialize_copy entirely and operate on a lower level.
