### PR TITLE
Syntax error in regular expression

### DIFF
--- a/lib/bibtex/lexer.rb
+++ b/lib/bibtex/lexer.rb
@@ -60,7 +60,7 @@ module BibTeX
       :comment      => /comment/io,
       :preamble     => /preamble/io,
       :key          => /[[:alpha:]\d \/:_!$\?\.%&\*-]+,/io,
-      :optional_key => /[[:alpha:]\d \/:_!$\?\.%&\*-]+*,/io
+      :optional_key => /[[:alpha:]\d \/:_!$\?\.%&\*-]*,/io
     }.freeze
     
     MODE = Hash.new(:meta).merge({


### PR DESCRIPTION
The gem fails in Ruby 1.8 with error message:

```
SyntaxError: /usr/lib/ruby/gems/1.8/gems/bibtex-ruby-2.0.11/lib/bibtex/lexer.rb:63: nested *?+ in regexp: /[[:alpha:]\d \/:_!$\?\.%&\*-]+*,/
```

In 1.9, you get the warning:

```
/Users/ruben/.rbenv/versions/1.9.2-p290/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36: warning: nested repeat operator + and * was replaced with '*': /[[:alpha:]\d \/:_!$\?\.%&\*-]+*,/
```

This commit corrects the regular expression.
