### PR TITLE
Fix broken test_0003_parses complex LaTeX markup(backslashes and escape sequences)

### DIFF
--- a/test/bibtex/test_parser.rb
+++ b/test/bibtex/test_parser.rb
@@ -87,7 +87,7 @@ module BibTeX
           }
         END
         b.booktitle.must_be :==, "Perception et Intermodalit\\'{e}: Approches Actuelles De La Question De Molyneux"
-        b.editor.must_be :==, 'Proust, Jo\"{e}lle'
+        b.editor.to_s.must_be :==, 'Proust, Jo\"{e}lle'
       end
       
     end


### PR DESCRIPTION
This commit fixes broken `test_0003_parses complex LaTeX markup(backslashes and escape sequences)` on Ruby 1.8.
