### PR TITLE
Fix for #61

### DIFF
--- a/lib/bibtex/entry.rb
+++ b/lib/bibtex/entry.rb
@@ -77,6 +77,7 @@ module BibTeX
       url       URL
       doi       DOI
       year      issued
+      type      genre
     }.map(&:intern)]).freeze
 
     CSL_FIELDS = %w{ abstract annote archive archive_location archive-place
@@ -696,11 +697,10 @@ module BibTeX
         hash[CSL_FILTER[k].to_s] = v.to_citeproc(options) unless DATE_FIELDS.include?(k)
       end
 
-			hash['id'] = key.to_s
-
-			hash['bibtex-type'] = hash['type'] if hash.key?('type')
-			hash['type'] = CSL_TYPES[type].to_s
-
+      hash['id'] = key.to_s
+      hash['type'] = CSL_TYPES[type].to_s
+      hash['genre'] = "Master's thesis" if (!hash.key?('genre') and type.to_s == "mastersthesis")
+      hash['genre'] = "PhD thesis" if (!hash.key?('genre') and type.to_s == "phdthesis")
       hash['issued'] = citeproc_date
 
       hash


### PR DESCRIPTION
CSL does not distinguish between different kinds of theses. According to the CSL spec 1.0.1 the kind of a thesis shall be specified in the "genre" field. In the case of @mastersthesis records, genre is populated with "Master's thesis", for @phdthesis genre is set to "PhD thesis". For both kinds of thesis, the "genre" field can be overridden by using the type file in BibTeX.
