### PR TITLE
make default_key transliterate non-ASCII characters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ gemspec
 # RDF Export
 gem 'rdf', '~>0.3'
 
+gem 'iconv'
+
 group :debug do
 	gem 'debugger', :require => false, :platforms => [:mri_19, :mri_20]
 	gem 'ruby-debug', :require => false, :platforms => [:mri_18]

--- a/features/step_definitions/bibtex_steps.rb
+++ b/features/step_definitions/bibtex_steps.rb
@@ -30,6 +30,26 @@ When /^I convert all entries using the filter "([^"]*)"$/ do |filter|
   @bibliography.convert(filter)
 end
 
+When /^I create an entry with these elements:$/ do |table|
+  @bibliography = BibTeX::Bibliography.new
+  entry = BibTeX::Entry.new
+  table.hashes.first.each_pair do |field, value|
+    entry[field.to_sym] = value
+  end
+  @bibliography << entry.parse_names
+end
+
+When /^I create entries with these elements:$/ do |table|
+  @bibliography = BibTeX::Bibliography.new
+  table.hashes.each do |entries|
+    entry = BibTeX::Entry.new
+    entries.each_pair do |field, value|
+      entry[field.to_sym] = value
+    end
+    @bibliography << entry.parse_names
+  end
+end
+
 
 Then /^my bibliography should contain the following objects:$/ do |table|
   @bibliography.each_with_index do |object, index|

--- a/lib/bibtex.rb
+++ b/lib/bibtex.rb
@@ -23,6 +23,8 @@ require 'open-uri'
 
 require 'multi_json'
 
+require 'iconv'
+
 require 'bibtex/version'
 
 # = BibTeX

--- a/lib/bibtex/entry.rb
+++ b/lib/bibtex/entry.rb
@@ -862,18 +862,22 @@ module BibTeX
 
 
     private
+    
+    # Returns +str+ transliterated containing only ASCII characters.
+    def transliterate(str)
+      (@iconv ||= Iconv.open('ascii//translit//ignore', 'utf-8')).iconv(str)
+    end
 
     # Returns a default key for this entry.
     def default_key
       k = names[0]
       k = k.respond_to?(:family) ? k.family : k.to_s
+      k = transliterate(k)
       k = k[/[A-Za-z]+/] || 'unknown'
       k << (has_field?(:year) ? year : '-')
       k << 'a'
       k.downcase!
       k
     end
-
-
   end
 end


### PR DESCRIPTION
Hello,

I ran into a problem with the generation of default_keys when dealing with names containing German umlauts. The following code, e. g., wouldreturn "m-a" as key instead of "muller-a" or "mueller-a".

```
e = BibTeX::Entry.new
e.author = "Christian Müller"
e.parse_names
e.key
```

My patch fixes this by changing the default_key method to transliterate the name using the iconv gem (meaning I only tested it under Ruby 2.0 where iconv has been removed from stdlib).

Im not entirely sure if this patch is useful since I do not know if bibtex-ruby should handle encodings at all or leave that task to its users. Anyway, I wanted to let you know.
