### PR TITLE
make parser recognize keys with non-ASCII characters

### DIFF
--- a/features/issues/non_ascii_keys.feature
+++ b/features/issues/non_ascii_keys.feature
@@ -1,0 +1,17 @@
+Feature: Keys containing non-ASCII characters
+	As a hacker who works with bibliographies
+	I want to parse BibTeX entries with keys containing non-ASCII characters
+	Because they can occur in many languages other than English
+	
+	Scenario: An entry whose key contains a German umlaut
+		When I parse the following file:
+		"""
+		@article{müller.2011,
+		  author    = {Christian Müller},
+		  title     = {Important article},
+		  journal   = {Not so important journal},
+		  volume    = {5},
+		  year      = {2011}
+		}
+		"""
+		Then my bibliography should contain an article with id "müller.2011"

--- a/lib/bibtex/lexer.rb
+++ b/lib/bibtex/lexer.rb
@@ -46,8 +46,8 @@ module BibTeX
       :braces       => /\{|\}/o,
       :eq           => /\s*=\s*/o,
       :comma        => /\s*,\s*/o,
-      :number       => /\d+/o,
-      :name         => /[[:alpha:]\d\/:_!$\?\.%&\*-]+/io,
+      :number       => /[[:digit:]]+/o,
+      :name         => /[[:alpha:][:digit:]\/:_!$\?\.%&\*-]+/io,
       :quote        => /\s*"/o,
       :unquote      => /[\{\}"]/o,
       :sharp        => /\s*#\s*/o,
@@ -59,8 +59,8 @@ module BibTeX
       :string       => /string/io,
       :comment      => /comment\b/io,
       :preamble     => /preamble\b/io,
-      :key          => /\s*[[:alpha:]\d \/:_!$\?\.%+&\*-]+,/io,
-      :optional_key => /\s*[[:alpha:]\d \/:_!$\?\.%+&\*-]*,/io
+      :key          => /\s*[[:alpha:][:digit:] \/:_!$\?\.%+&\*-]+,/io,
+      :optional_key => /\s*[[:alpha:][:digit:] \/:_!$\?\.%+&\*-]*,/io
     }.freeze
     
     MODE = Hash.new(:meta).merge({


### PR DESCRIPTION
Hello,

I found out that the BibTeX parser was not able to correctly parse keys containing umlauts, e. g. "müller.2011", instead giving me the warning `Lexer: unexpected token `ü'`. When I changed the relevant regular expressions to use `[:digit:]` instead of previous `\d` everything worked as expected, although I'm not exactly sure why.

Regards,
Christoph
