### PR TITLE
BibTeX citeproc updates: missing fields and 'proceedings' and 'misc' types

### DIFF
--- a/lib/bibtex/entry/citeproc_converter.rb
+++ b/lib/bibtex/entry/citeproc_converter.rb
@@ -15,6 +15,7 @@ class BibTeX::Entry::CiteProcConverter
     school       publisher
     institution  publisher
     organization publisher
+    howpublished publisher
   }.map(&:intern)]).freeze
 
   CSL_FIELDS = %w{
@@ -38,7 +39,6 @@ class BibTeX::Entry::CiteProcConverter
     inproceedings  paper-conference
     manual         book
     mastersthesis  thesis
-    misc           article
     phdthesis      thesis
     proceedings    book
     techreport     report


### PR DESCRIPTION
Updated handling of BibTeX to CSL conversion:
- `@proceedings` type should be mapped to `book`
- mapping `school`, `institution` and `organization` fields to `publisher`
- handle `@misc` type as "no type", rather than article. Also map `howpublished` field to `publisher`

I have not added any tests, since I don't know Ruby well. Also, a couple tests were failing on master before these changes anyway..

Addresses issues #72 and #85.
