### PR TITLE
allow selecting entries /not/ matching an attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ query functionality with the exception of yielding to a block. For instance:
     => Returns all books whose keywords attribute matches /^ruby/
     bib.q('@book[keywords ~= ruby]')
     => Returns all books whose keywords attribute matches /ruby/
+    bib['@book[keywords!~ruby]']
+    => Returns all books whose keywords attribute does not match /ruby/ or don't have keywords attribute
 
     bib.q('@article[year<=2007]')
     => Returns all articles published in 2007 or earlier

--- a/features/query.feature
+++ b/features/query.feature
@@ -59,6 +59,8 @@ Feature: Searching in BibTeX bibliographies
 		Then there should be exactly 3 matches
 		When I search for "@*[year=2007]"
 		Then there should be exactly 1 match
+		When I search for "@*[keywords!~lex]"
+		Then there should be exactly 2 matches
 		
 	@query
 	Scenario: Find entries using compound queries

--- a/lib/bibtex/elements.rb
+++ b/lib/bibtex/elements.rb
@@ -191,7 +191,7 @@ module BibTeX
     private
     
     def meets_condition?(condition)
-      property, operator, value = condition.split(/\s*([!~\/\^<>]?=)\s*/)
+      property, operator, value = condition.split(/\s*([!~\/\^<>]?=|!~)\s*/)
 
       if property.nil?
         true
@@ -208,6 +208,8 @@ module BibTeX
             !actual.nil? && actual.to_s.match("^#{value}")
           when '~='
             !actual.nil? && actual.to_s.match(value)
+          when '!~'
+            actual.nil? || !actual.to_s.match(value)
           when '<='
             !actual.nil? && actual.to_i <= value.to_i
           when '>='


### PR DESCRIPTION
there are various kinds of "@incollections" papers, e.g. workshop papers, which I don't want to put in the same list as other papers on my website. This commit allows to use an attribute like a tag list, where you can select or exclude entries.

On the choice of operator (`%=`): I'm not too fond of it, I'd prefer to use perl notation (`=~` and `!~`), but that would break compatibility. Feel free to suggest an alternative.
