### PR TITLE
correct a typo

### DIFF
--- a/lib/bibtex/error.rb
+++ b/lib/bibtex/error.rb
@@ -1,14 +1,14 @@
 module BibTeX
 
-	class BibTeXError < StandardError	
-		attr_reader :orginal
-		
+	class BibTeXError < StandardError
+		attr_reader :original
+
 		def initialize(message = nil, original = $!)
 			super(message)
 			@original = original
 		end
 	end
-	
+
   class ParseError < BibTeXError; end
   class ArgumentError < BibTeXError; end
 
@@ -16,29 +16,29 @@ module BibTeX
   # Represents a lexical or syntactical error.
   #
   class Error < Element
-    
+
     attr_reader :trace
-    
+
     def initialize(trace=[])
       @trace = trace
     end
-  
+
     def trace=(trace)
       raise(ArgumentError, "BibTeX::Error trace must be of type Array; was: #{trace.class.name}.") unless trace.kind_of?(Array)
       @trace = trace
     end
-    
+
     def content
       @trace.map { |e| e[1] }.join
     end
-    
+
     # Called when the element was added to a bibliography.
     def added_to_bibliography(bibliography)
       super(bibliography)
       bibliography.errors << self
       self
     end
-    
+
     # Called when the element was removed from a bibliography.
     def removed_from_bibliography(bibliography)
       super(bibliography)


### PR DESCRIPTION
On saving the corrected version, my editor removed some whitespace. I can undo that if you wish.
