### PR TITLE
Allow logger to be assigned

### DIFF
--- a/lib/bibtex.rb
+++ b/lib/bibtex.rb
@@ -46,7 +46,7 @@ module BibTeX
 	@log.datetime_format = '%Y-%m-%d %H:%M:%S'
 
   class << self
-    attr_reader :log
+    attr_accessor :log
   end
 
 end

--- a/test/test_bibtex.rb
+++ b/test/test_bibtex.rb
@@ -96,6 +96,12 @@ module BibTeX
       bib.replace_strings
 			assert_equal 'The Pragmatic Bookshelf', bib['rails'].publisher
     end
+
+    def test_logger_can_be_assigned
+      logger = BibTeX.log
+      BibTeX.log = logger
+    end
+
   end
 
 end


### PR DESCRIPTION
We're using bibtex-ruby in a Rails app and we would like to be able to redirect log output from bibtex-ruby to the Rails logger.
