### PR TITLE
Fix infinite loop in Entry#register

### DIFF
--- a/lib/bibtex/entry.rb
+++ b/lib/bibtex/entry.rb
@@ -456,6 +456,19 @@ module BibTeX
       !!(bibliography && bibliography.entries[key].equal?(self))
     end
 
+    module EmptySucc #:nodoc:
+      SUCC = '0'
+
+      # Avoid infinite loop in Entry#register for an empty string
+      def succ!
+        if empty?
+          concat SUCC
+        else
+          super
+        end
+      end
+    end
+
     # Registers this Entry in the associated Bibliographies entries hash.
     # This method may change the Entry's key, if another entry is already
     # registered with the current key.
@@ -464,7 +477,7 @@ module BibTeX
     def register(key)
       return nil if bibliography.nil?
 
-      k = key.dup
+      k = key.dup.extend(EmptySucc)
       k.succ! while bibliography.has_key?(k)
       bibliography.entries[k] = self
       k

--- a/lib/bibtex/entry.rb
+++ b/lib/bibtex/entry.rb
@@ -460,19 +460,6 @@ module BibTeX
       !!(bibliography && bibliography.entries[key].equal?(self))
     end
 
-    module EmptySucc #:nodoc:
-      SUCC = '0'
-
-      # Avoid infinite loop in Entry#register for an empty string
-      def succ!
-        if empty?
-          concat SUCC
-        else
-          super
-        end
-      end
-    end
-
     # Registers this Entry in the associated Bibliographies entries hash.
     # This method may change the Entry's key, if another entry is already
     # registered with the current key.
@@ -481,7 +468,7 @@ module BibTeX
     def register(key)
       return nil if bibliography.nil?
 
-      k = key.dup.extend(EmptySucc)
+      k = key.dup
       k.succ! while bibliography.has_key?(k)
       bibliography.entries[k] = self
       k

--- a/lib/bibtex/entry.rb
+++ b/lib/bibtex/entry.rb
@@ -193,7 +193,11 @@ module BibTeX
     end
 
     def key
-      @key ||= default_key
+      if @key.nil? || @key.empty?
+        @key = default_key
+      else
+        @key
+      end
     end
 
     alias id key

--- a/test/test_bibtex.rb
+++ b/test/test_bibtex.rb
@@ -102,6 +102,19 @@ module BibTeX
       BibTeX.log = logger
     end
 
+    def test_missing_key
+      assert_raises(BibTeX::ParseError) do
+        BibTeX.parse(<<EOF)
+        @article{}
+EOF
+      end
+      assert(
+        BibTeX.parse(<<EOF, allow_missing_keys: true)
+        @article{}
+EOF
+      )
+    end
+
   end
 
 end

--- a/test/test_bibtex.rb
+++ b/test/test_bibtex.rb
@@ -1,4 +1,5 @@
 require 'helper.rb'
+require 'timeout'
 
 module BibTeX
   class TestBibtex < Minitest::Unit::TestCase
@@ -113,6 +114,12 @@ EOF
         @article{}
 EOF
       )
+      timeout(2) do
+        BibTeX.parse(<<EOF, allow_missing_keys: true)
+        @article{},
+        @article{}
+EOF
+      end
     end
 
   end


### PR DESCRIPTION
This patch fixes an infinite loop invoked by codes such as bellow.

```ruby
BibTeX.parse(<<EOF, allow_missing_keys: true)
@article{},
@article{}
EOF
```

Perhaps it is little bit too noisy...