### PR TITLE
Fix Bibliography#add to respect options privided to #initialize

### DIFF
--- a/lib/bibtex/bibliography.rb
+++ b/lib/bibtex/bibliography.rb
@@ -118,7 +118,7 @@ module BibTeX
     # Adds a new element, or a list of new elements to the bibliography.
     # Returns the Bibliography for chainability.
     def add(*arguments)
-      Element.parse(arguments.flatten).each do |element|
+      Element.parse(arguments.flatten, @options).each do |element|
         data << element.added_to_bibliography(self)
       end
       self

--- a/test/bibtex/test_bibliography.rb
+++ b/test/bibtex/test_bibliography.rb
@@ -417,6 +417,15 @@ module BibTeX
       end
     end
 
+    describe '#add' do
+      before do
+        @bib = Bibliography.new(allow_missing_keys: true)
+      end
 
+      it 'should respect options provided to initializer' do
+        assert_equal(@bib.add('@article{, title = test}'), @bib)
+        assert(! @bib.entries.keys.any?(&:empty?))
+      end
+    end
   end
 end


### PR DESCRIPTION
This patch fixes Bibliography#add, where options provided to Bibliography.new are not respected currently.