### PR TITLE
Compatibility with the latest version of rdf gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,6 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'rdf', '~>2.0'
-gem 'rdf-vocab', '~>2.0
-'
 gem 'json', '~>1.8', :platforms => [:mri_18, :jruby, :rbx]
 
 gem 'rubysl', '~>2.0', :platforms => :rbx
@@ -11,8 +8,11 @@ gem 'rubysl', '~>2.0', :platforms => :rbx
 group :debug do
   if RUBY_VERSION >= '2.0'
     gem 'byebug', :require => false, :platforms => :mri
+    gem 'rdf', '~>2.0'
+    gem 'rdf-vocab', '~>2.0'
   else
     gem 'debugger', :require => false, :platforms => :mri
+    gem 'rdf', '~>1.1'
   end
 
   gem 'ruby-debug', :require => false, :platforms => :jruby

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,13 @@ gemspec
 
 gem 'json', '~>1.8', :platforms => [:mri_18, :jruby, :rbx]
 
+if RUBY_VERSION >= '2.0'
+  gem 'rdf', '~>2.0'
+  gem 'rdf-vocab', '~>2.0'
+else
+  gem 'rdf', '~>1.1'
+end
+
 gem 'rubysl', '~>2.0', :platforms => :rbx
 
 group :debug do

--- a/Gemfile
+++ b/Gemfile
@@ -15,11 +15,8 @@ gem 'rubysl', '~>2.0', :platforms => :rbx
 group :debug do
   if RUBY_VERSION >= '2.0'
     gem 'byebug', :require => false, :platforms => :mri
-    gem 'rdf', '~>2.0'
-    gem 'rdf-vocab', '~>2.0'
   else
     gem 'debugger', :require => false, :platforms => :mri
-    gem 'rdf', '~>1.1'
   end
 
   gem 'ruby-debug', :require => false, :platforms => :jruby

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'rdf', '~>1.1'
+gem 'rdf', '~>2.0'
 gem 'json', '~>1.8', :platforms => [:mri_18, :jruby, :rbx]
 
 gem 'rubysl', '~>2.0', :platforms => :rbx

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rdf', '~>2.0'
+gem 'rdf-vocab', '~>2.0
+'
 gem 'json', '~>1.8', :platforms => [:mri_18, :jruby, :rbx]
 
 gem 'rubysl', '~>2.0', :platforms => :rbx

--- a/lib/bibtex.rb
+++ b/lib/bibtex.rb
@@ -76,6 +76,7 @@ require 'bibtex/utilities'
 
 begin
   require 'rdf'
+  require 'rdf/vocab'
   require 'bibtex/entry/rdf_converter'
   require 'bibtex/bibliography/rdf_converter'
 rescue LoadError

--- a/lib/bibtex.rb
+++ b/lib/bibtex.rb
@@ -76,7 +76,9 @@ require 'bibtex/utilities'
 
 begin
   require 'rdf'
-  require 'rdf/vocab'
+  if Gem.loaded_specs["rdf"].version >= Gem::Version.create('2.0')
+    require 'rdf/vocab'
+  end
   require 'bibtex/entry/rdf_converter'
   require 'bibtex/bibliography/rdf_converter'
 rescue LoadError

--- a/lib/bibtex/entry/rdf_converter.rb
+++ b/lib/bibtex/entry/rdf_converter.rb
@@ -1,10 +1,6 @@
 require 'uri/common'
 
-if Gem.loaded_specs["rdf"].version < Gem::Version.create('2.0')
-  RDFVocab = RDF
-else
-  RDFVovab = RDF::Vocab
-end
+RDFVocab = defined?(RDF::Vocab) ? RDF::Vocab : RDF
 
 class BibTeX::Entry::RDFConverter
   DEFAULT_REMOVE_FROM_FALLBACK = %w(
@@ -299,7 +295,7 @@ class BibTeX::Entry::RDFConverter
 
     graph << [entry, RDFVocab::DC.Location, bibtex[:location].to_s]
     if [:proceedings, :inproceedings, :conference].include?(bibtex.type)
-      event = RDFVocabulary.new('http://purl.org/NET/c4dm/event.owl')
+      event = RDF::Vocabulary.new('http://purl.org/NET/c4dm/event.owl')
       graph << [entry, event[:place], org]
     end
   end
@@ -389,7 +385,7 @@ class BibTeX::Entry::RDFConverter
       end
 
     if bibtex.field?(:address)
-      address = RDFVocabulary.new('http://schemas.talis.com/2005/address/schema#')
+      address = RDF::Vocabulary.new('http://schemas.talis.com/2005/address/schema#')
       graph << [org, address[:localityName], bibtex[:address]]
     end
 
@@ -525,7 +521,7 @@ class BibTeX::Entry::RDFConverter
   private
 
   def bibo
-    @bibo ||= RDFVocabulary.new('http://purl.org/ontology/bibo/')
+    @bibo ||= RDF::Vocabulary.new('http://purl.org/ontology/bibo/')
   end
 
   def bibo_class
@@ -580,7 +576,7 @@ class BibTeX::Entry::RDFConverter
   def run_fallback
     return if fallback.empty?
 
-    ml = RDFVocabulary.new('http://bibtexml.sf.net/')
+    ml = RDF::Vocabulary.new('http://bibtexml.sf.net/')
     fallback.each do |field|
       graph << [entry, ml[field], bibtex[field]]
     end

--- a/lib/bibtex/entry/rdf_converter.rb
+++ b/lib/bibtex/entry/rdf_converter.rb
@@ -1,5 +1,11 @@
 require 'uri/common'
 
+if Gem.loaded_specs["rdf"].version < Gem::Version.create('2.0')
+  RDFVocab = RDF
+else
+  RDFVovab = RDF::Vocab
+end
+
 class BibTeX::Entry::RDFConverter
   DEFAULT_REMOVE_FROM_FALLBACK = %w(
     bdsk-file-1
@@ -62,7 +68,7 @@ class BibTeX::Entry::RDFConverter
     return unless bibtex.field?(:abstract)
     remove_from_fallback(:abstract)
 
-    graph << [entry, RDF::Vocab::DC.abstract, bibtex[:abstract].to_s]
+    graph << [entry, RDFVocab::DC.abstract, bibtex[:abstract].to_s]
     graph << [entry, bibo[:abstract], bibtex[:abstract].to_s]
   end
 
@@ -89,7 +95,7 @@ class BibTeX::Entry::RDFConverter
     bibtex[:author].each do |name|
       node = agent(name) { create_agent(name, :Person) }
 
-      graph << [entry, RDF::Vocab::DC.creator, node]
+      graph << [entry, RDFVocab::DC.creator, node]
       graph << [seq, RDF.li, node]
     end
   end
@@ -99,7 +105,7 @@ class BibTeX::Entry::RDFConverter
     while bibtex.field?("bdsk-url-#{count}".to_sym) do
       field = "bdsk-url-#{count}".to_sym
       remove_from_fallback(field)
-      graph << [entry, RDF::Vocab::DC.URI, bibtex[field].to_s]
+      graph << [entry, RDFVocab::DC.URI, bibtex[field].to_s]
       graph << [entry, bibo[:uri], bibtex[field].to_s]
       count  += 1
     end
@@ -118,9 +124,9 @@ class BibTeX::Entry::RDFConverter
 
     series = RDF::Node.new
     graph << [series, RDF.type, bibo[:Document]]
-    graph << [series, RDF::Vocab::DC.title, bibtex[:booktitle].to_s]
+    graph << [series, RDFVocab::DC.title, bibtex[:booktitle].to_s]
 
-    graph << [entry, RDF::Vocab::DC.isPartOf, series]
+    graph << [entry, RDFVocab::DC.isPartOf, series]
   end
 
   def chapter
@@ -136,7 +142,7 @@ class BibTeX::Entry::RDFConverter
     bibtex.children.each do |child|
       child_id = RDF::URI.new(child.identifier)
       BibTeX::Entry::RDFConverter.new(child, graph, agent).convert! unless uri_in_graph?(child_id)
-      graph << [entry, RDF::Vocab::DC.hasPart, child_id]
+      graph << [entry, RDFVocab::DC.hasPart, child_id]
     end
   end
 
@@ -144,21 +150,21 @@ class BibTeX::Entry::RDFConverter
     return unless bibtex.field?(:copyright)
     remove_from_fallback(:copyright)
 
-    graph << [entry, RDF::Vocab::DC.rightsHolder, bibtex[:copyright].to_s]
+    graph << [entry, RDFVocab::DC.rightsHolder, bibtex[:copyright].to_s]
   end
 
   def date_added
     return unless bibtex.field?(:'date-added')
     remove_from_fallback(:'date-added')
 
-    graph << [entry, RDF::Vocab::DC.created, bibtex[:'date-added'].to_s]
+    graph << [entry, RDFVocab::DC.created, bibtex[:'date-added'].to_s]
   end
 
   def date_modified
     return unless bibtex.field?(:'date-modified')
     remove_from_fallback(:'date-modified')
 
-    graph << [entry, RDF::Vocab::DC.modified, bibtex[:'date-modified'].to_s]
+    graph << [entry, RDFVocab::DC.modified, bibtex[:'date-modified'].to_s]
   end
 
   def doi
@@ -166,7 +172,7 @@ class BibTeX::Entry::RDFConverter
     remove_from_fallback(:doi)
 
     graph << [entry, bibo[:doi], bibtex[:doi].to_s]
-    graph << [entry, RDF::Vocab::DC.identifier, "doi:#{bibtex[:doi].to_s}"]
+    graph << [entry, RDFVocab::DC.identifier, "doi:#{bibtex[:doi].to_s}"]
   end
 
   def edition
@@ -202,7 +208,7 @@ class BibTeX::Entry::RDFConverter
     return unless bibtex[:howpublished] =~ /^#{URI.regexp}$/
     remove_from_fallback(:howpublished)
 
-    graph << [entry, RDF::Vocab::DC.URI, bibtex[:howpublished].to_s]
+    graph << [entry, RDFVocab::DC.URI, bibtex[:howpublished].to_s]
     graph << [entry, bibo[:uri], bibtex[:howpublished].to_s]
   end
 
@@ -212,7 +218,7 @@ class BibTeX::Entry::RDFConverter
 
     org = agent(bibtex[:institution].to_s) { create_agent(bibtex[:institution].to_s, :Organization) }
 
-    graph << [entry, RDF::Vocab::DC.contributor, org]
+    graph << [entry, RDFVocab::DC.contributor, org]
   end
 
   def isbn
@@ -222,9 +228,9 @@ class BibTeX::Entry::RDFConverter
     graph << [entry, bibo[:isbn], bibtex[:isbn].to_s]
 
     if bibtex.contained?
-      graph << [entry, RDF::Vocab::DC.isPartOf, "urn:isbn:#{bibtex[:isbn].to_s}"]
+      graph << [entry, RDFVocab::DC.isPartOf, "urn:isbn:#{bibtex[:isbn].to_s}"]
     else
-      graph << [entry, RDF::Vocab::DC.identifier, "urn:isbn:#{bibtex[:isbn].to_s}"]
+      graph << [entry, RDFVocab::DC.identifier, "urn:isbn:#{bibtex[:isbn].to_s}"]
     end
   end
 
@@ -234,9 +240,9 @@ class BibTeX::Entry::RDFConverter
 
     graph << [entry, bibo[:issn], bibtex[:issn].to_s]
     if bibtex.contained?
-      graph << [entry, RDF::Vocab::DC.isPartOf, "urn:issn:#{bibtex[:issn].to_s}"]
+      graph << [entry, RDFVocab::DC.isPartOf, "urn:issn:#{bibtex[:issn].to_s}"]
     else
-      graph << [entry, RDF::Vocab::DC.identifier, "urn:issn:#{bibtex[:issn].to_s}"]
+      graph << [entry, RDFVocab::DC.identifier, "urn:issn:#{bibtex[:issn].to_s}"]
     end
   end
 
@@ -250,7 +256,7 @@ class BibTeX::Entry::RDFConverter
     source << "No. #{bibtex[:number].to_s}" if bibtex.field?(:number)
     pagination = bibtex[:pagination] || 'pp.'
     source << "#{pagination.to_s} #{bibtex[:pages].to_s}" if bibtex.field?(:pages)
-    graph << [entry, RDF::Vocab::DC.source, source.join(', ')]
+    graph << [entry, RDFVocab::DC.source, source.join(', ')]
   end
 
   def journal_dc_part_of
@@ -260,13 +266,13 @@ class BibTeX::Entry::RDFConverter
 
     journal = RDF::Node.new
     graph << [journal, RDF.type, bibo[:Journal]]
-    graph << [journal, RDF::Vocab::DC.title, bibtex[:journal].to_s]
+    graph << [journal, RDFVocab::DC.title, bibtex[:journal].to_s]
 
-    graph << [entry, RDF::Vocab::DC.isPartOf, journal]
+    graph << [entry, RDFVocab::DC.isPartOf, journal]
   end
 
   def key
-    graph << [entry, RDF::Vocab::DC.identifier, "urn:bibtex:#{bibtex.key}"]
+    graph << [entry, RDFVocab::DC.identifier, "urn:bibtex:#{bibtex.key}"]
   end
 
   def keywords
@@ -274,7 +280,7 @@ class BibTeX::Entry::RDFConverter
     remove_from_fallback(:keywords)
 
     bibtex[:keywords].to_s.split(/\s*[,;]\s*/).each do |keyword|
-      graph << [entry, RDF::Vocab::DC.subject, keyword]
+      graph << [entry, RDFVocab::DC.subject, keyword]
     end
   end
 
@@ -284,16 +290,16 @@ class BibTeX::Entry::RDFConverter
 
     bibtex[:language] = 'german' if bibtex[:language] == 'ngerman'
 
-    graph << [entry, RDF::Vocab::DC.language, bibtex[:language].to_s]
+    graph << [entry, RDFVocab::DC.language, bibtex[:language].to_s]
   end
 
   def location
     return unless bibtex.field?(:location)
     remove_from_fallback(:location)
 
-    graph << [entry, RDF::Vocab::DC.Location, bibtex[:location].to_s]
+    graph << [entry, RDFVocab::DC.Location, bibtex[:location].to_s]
     if [:proceedings, :inproceedings, :conference].include?(bibtex.type)
-      event = RDF::Vocabulary.new('http://purl.org/NET/c4dm/event.owl')
+      event = RDFVocabulary.new('http://purl.org/NET/c4dm/event.owl')
       graph << [entry, event[:place], org]
     end
   end
@@ -334,7 +340,7 @@ class BibTeX::Entry::RDFConverter
 
     org = agent(bibtex[:organization].to_s) { create_agent(bibtex[:organization].to_s, :Organization) }
 
-    graph << [entry, RDF::Vocab::DC.contributor, org]
+    graph << [entry, RDFVocab::DC.contributor, org]
     graph << [entry, bibo[:organizer], org] if [:proceedings, :inproceedings, :conference].include?(bibtex.type)
   end
 
@@ -363,7 +369,7 @@ class BibTeX::Entry::RDFConverter
 
     parent_id = RDF::URI.new(bibtex.parent.identifier)
     BibTeX::Entry::RDFConverter.new(bibtex.parent, graph, agent).convert! unless uri_in_graph?(parent_id)
-    graph << [entry, RDF::Vocab::DC.isPartOf, parent_id]
+    graph << [entry, RDFVocab::DC.isPartOf, parent_id]
   end
 
   def publisher
@@ -383,11 +389,11 @@ class BibTeX::Entry::RDFConverter
       end
 
     if bibtex.field?(:address)
-      address = RDF::Vocabulary.new('http://schemas.talis.com/2005/address/schema#')
+      address = RDFVocabulary.new('http://schemas.talis.com/2005/address/schema#')
       graph << [org, address[:localityName], bibtex[:address]]
     end
 
-    graph << [entry, RDF::Vocab::DC.publisher, org]
+    graph << [entry, RDFVocab::DC.publisher, org]
     graph << [entry, bibo[:publisher], org]
   end
 
@@ -397,7 +403,7 @@ class BibTeX::Entry::RDFConverter
 
     org = agent(bibtex[:school].to_s) { create_agent(bibtex[:school].to_s, :Organization) }
 
-    graph << [entry, RDF::Vocab::DC.contributor, org]
+    graph << [entry, RDFVocab::DC.contributor, org]
   end
 
   def series
@@ -409,9 +415,9 @@ class BibTeX::Entry::RDFConverter
 
     series = RDF::Node.new
     graph << [series, RDF.type, bibo[:MultiVolumeBook]]
-    graph << [series, RDF::Vocab::DC.title, bibtex[:series].to_s]
+    graph << [series, RDFVocab::DC.title, bibtex[:series].to_s]
 
-    graph << [entry, RDF::Vocab::DC.isPartOf, series]
+    graph << [entry, RDFVocab::DC.isPartOf, series]
   end
 
   def thesis_degree
@@ -449,7 +455,7 @@ class BibTeX::Entry::RDFConverter
     title = [bibtex[:title].to_s, bibtex[:subtitle].to_s]
       .reject { |t| t.nil? || t.empty? }
       .join(': ')
-    graph << [entry, RDF::Vocab::DC.title, title]
+    graph << [entry, RDFVocab::DC.title, title]
     graph << [entry, bibo[:shortTitle], bibtex[:title].to_s] if bibtex.field?(:subtitle)
   end
 
@@ -461,7 +467,7 @@ class BibTeX::Entry::RDFConverter
       create_agent(bibtex[:translator].to_s, :Person)
     end
 
-    graph << [entry, RDF::Vocab::DC.contributor, node]
+    graph << [entry, RDFVocab::DC.contributor, node]
     graph << [entry, bibo[:translator], node]
   end
 
@@ -470,9 +476,9 @@ class BibTeX::Entry::RDFConverter
 
     case bibtex.type
     when :proceedings, :journal
-      graph << [entry, RDF::Vocab::DC.type, 'Collection']
+      graph << [entry, RDFVocab::DC.type, 'Collection']
     else
-      graph << [entry, RDF::Vocab::DC.type, 'Text']
+      graph << [entry, RDFVocab::DC.type, 'Text']
     end
   end
 
@@ -480,7 +486,7 @@ class BibTeX::Entry::RDFConverter
     return unless bibtex.field?(:url)
     remove_from_fallback(:url)
 
-    graph << [entry, RDF::Vocab::DC.URI, bibtex[:url].to_s]
+    graph << [entry, RDFVocab::DC.URI, bibtex[:url].to_s]
     graph << [entry, bibo[:uri], bibtex[:url].to_s]
   end
 
@@ -509,7 +515,7 @@ class BibTeX::Entry::RDFConverter
     end
     date = month.nil? ? year : [year, month].join('-')
 
-    graph << [entry, RDF::Vocab::DC.issued, date]
+    graph << [entry, RDFVocab::DC.issued, date]
   end
 
   protected
@@ -519,7 +525,7 @@ class BibTeX::Entry::RDFConverter
   private
 
   def bibo
-    @bibo ||= RDF::Vocabulary.new('http://purl.org/ontology/bibo/')
+    @bibo ||= RDFVocabulary.new('http://purl.org/ontology/bibo/')
   end
 
   def bibo_class
@@ -542,8 +548,8 @@ class BibTeX::Entry::RDFConverter
   def create_agent(name, type)
     node = RDF::Node.new
 
-    graph << [node, RDF.type, RDF::Vocab::FOAF[type]]
-    graph << [node, RDF::Vocab::FOAF.name, name.to_s]
+    graph << [node, RDF.type, RDFVocab::FOAF[type]]
+    graph << [node, RDFVocab::FOAF.name, name.to_s]
 
     if name.is_a?(BibTeX::Name)
       [:given, :family, :prefix, :suffix].each do |part|
@@ -574,7 +580,7 @@ class BibTeX::Entry::RDFConverter
   def run_fallback
     return if fallback.empty?
 
-    ml = RDF::Vocabulary.new('http://bibtexml.sf.net/')
+    ml = RDFVocabulary.new('http://bibtexml.sf.net/')
     fallback.each do |field|
       graph << [entry, ml[field], bibtex[field]]
     end

--- a/lib/bibtex/entry/rdf_converter.rb
+++ b/lib/bibtex/entry/rdf_converter.rb
@@ -62,7 +62,7 @@ class BibTeX::Entry::RDFConverter
     return unless bibtex.field?(:abstract)
     remove_from_fallback(:abstract)
 
-    graph << [entry, RDF::DC.abstract, bibtex[:abstract].to_s]
+    graph << [entry, RDF::Vocab::DC.abstract, bibtex[:abstract].to_s]
     graph << [entry, bibo[:abstract], bibtex[:abstract].to_s]
   end
 
@@ -89,7 +89,7 @@ class BibTeX::Entry::RDFConverter
     bibtex[:author].each do |name|
       node = agent(name) { create_agent(name, :Person) }
 
-      graph << [entry, RDF::DC.creator, node]
+      graph << [entry, RDF::Vocab::DC.creator, node]
       graph << [seq, RDF.li, node]
     end
   end
@@ -99,7 +99,7 @@ class BibTeX::Entry::RDFConverter
     while bibtex.field?("bdsk-url-#{count}".to_sym) do
       field = "bdsk-url-#{count}".to_sym
       remove_from_fallback(field)
-      graph << [entry, RDF::DC.URI, bibtex[field].to_s]
+      graph << [entry, RDF::Vocab::DC.URI, bibtex[field].to_s]
       graph << [entry, bibo[:uri], bibtex[field].to_s]
       count  += 1
     end
@@ -118,9 +118,9 @@ class BibTeX::Entry::RDFConverter
 
     series = RDF::Node.new
     graph << [series, RDF.type, bibo[:Document]]
-    graph << [series, RDF::DC.title, bibtex[:booktitle].to_s]
+    graph << [series, RDF::Vocab::DC.title, bibtex[:booktitle].to_s]
 
-    graph << [entry, RDF::DC.isPartOf, series]
+    graph << [entry, RDF::Vocab::DC.isPartOf, series]
   end
 
   def chapter
@@ -136,7 +136,7 @@ class BibTeX::Entry::RDFConverter
     bibtex.children.each do |child|
       child_id = RDF::URI.new(child.identifier)
       BibTeX::Entry::RDFConverter.new(child, graph, agent).convert! unless uri_in_graph?(child_id)
-      graph << [entry, RDF::DC.hasPart, child_id]
+      graph << [entry, RDF::Vocab::DC.hasPart, child_id]
     end
   end
 
@@ -144,21 +144,21 @@ class BibTeX::Entry::RDFConverter
     return unless bibtex.field?(:copyright)
     remove_from_fallback(:copyright)
 
-    graph << [entry, RDF::DC.rightsHolder, bibtex[:copyright].to_s]
+    graph << [entry, RDF::Vocab::DC.rightsHolder, bibtex[:copyright].to_s]
   end
 
   def date_added
     return unless bibtex.field?(:'date-added')
     remove_from_fallback(:'date-added')
 
-    graph << [entry, RDF::DC.created, bibtex[:'date-added'].to_s]
+    graph << [entry, RDF::Vocab::DC.created, bibtex[:'date-added'].to_s]
   end
 
   def date_modified
     return unless bibtex.field?(:'date-modified')
     remove_from_fallback(:'date-modified')
 
-    graph << [entry, RDF::DC.modified, bibtex[:'date-modified'].to_s]
+    graph << [entry, RDF::Vocab::DC.modified, bibtex[:'date-modified'].to_s]
   end
 
   def doi
@@ -166,7 +166,7 @@ class BibTeX::Entry::RDFConverter
     remove_from_fallback(:doi)
 
     graph << [entry, bibo[:doi], bibtex[:doi].to_s]
-    graph << [entry, RDF::DC.identifier, "doi:#{bibtex[:doi].to_s}"]
+    graph << [entry, RDF::Vocab::DC.identifier, "doi:#{bibtex[:doi].to_s}"]
   end
 
   def edition
@@ -202,7 +202,7 @@ class BibTeX::Entry::RDFConverter
     return unless bibtex[:howpublished] =~ /^#{URI.regexp}$/
     remove_from_fallback(:howpublished)
 
-    graph << [entry, RDF::DC.URI, bibtex[:howpublished].to_s]
+    graph << [entry, RDF::Vocab::DC.URI, bibtex[:howpublished].to_s]
     graph << [entry, bibo[:uri], bibtex[:howpublished].to_s]
   end
 
@@ -212,7 +212,7 @@ class BibTeX::Entry::RDFConverter
 
     org = agent(bibtex[:institution].to_s) { create_agent(bibtex[:institution].to_s, :Organization) }
 
-    graph << [entry, RDF::DC.contributor, org]
+    graph << [entry, RDF::Vocab::DC.contributor, org]
   end
 
   def isbn
@@ -222,9 +222,9 @@ class BibTeX::Entry::RDFConverter
     graph << [entry, bibo[:isbn], bibtex[:isbn].to_s]
 
     if bibtex.contained?
-      graph << [entry, RDF::DC.isPartOf, "urn:isbn:#{bibtex[:isbn].to_s}"]
+      graph << [entry, RDF::Vocab::DC.isPartOf, "urn:isbn:#{bibtex[:isbn].to_s}"]
     else
-      graph << [entry, RDF::DC.identifier, "urn:isbn:#{bibtex[:isbn].to_s}"]
+      graph << [entry, RDF::Vocab::DC.identifier, "urn:isbn:#{bibtex[:isbn].to_s}"]
     end
   end
 
@@ -234,9 +234,9 @@ class BibTeX::Entry::RDFConverter
 
     graph << [entry, bibo[:issn], bibtex[:issn].to_s]
     if bibtex.contained?
-      graph << [entry, RDF::DC.isPartOf, "urn:issn:#{bibtex[:issn].to_s}"]
+      graph << [entry, RDF::Vocab::DC.isPartOf, "urn:issn:#{bibtex[:issn].to_s}"]
     else
-      graph << [entry, RDF::DC.identifier, "urn:issn:#{bibtex[:issn].to_s}"]
+      graph << [entry, RDF::Vocab::DC.identifier, "urn:issn:#{bibtex[:issn].to_s}"]
     end
   end
 
@@ -250,7 +250,7 @@ class BibTeX::Entry::RDFConverter
     source << "No. #{bibtex[:number].to_s}" if bibtex.field?(:number)
     pagination = bibtex[:pagination] || 'pp.'
     source << "#{pagination.to_s} #{bibtex[:pages].to_s}" if bibtex.field?(:pages)
-    graph << [entry, RDF::DC.source, source.join(', ')]
+    graph << [entry, RDF::Vocab::DC.source, source.join(', ')]
   end
 
   def journal_dc_part_of
@@ -260,13 +260,13 @@ class BibTeX::Entry::RDFConverter
 
     journal = RDF::Node.new
     graph << [journal, RDF.type, bibo[:Journal]]
-    graph << [journal, RDF::DC.title, bibtex[:journal].to_s]
+    graph << [journal, RDF::Vocab::DC.title, bibtex[:journal].to_s]
 
-    graph << [entry, RDF::DC.isPartOf, journal]
+    graph << [entry, RDF::Vocab::DC.isPartOf, journal]
   end
 
   def key
-    graph << [entry, RDF::DC.identifier, "urn:bibtex:#{bibtex.key}"]
+    graph << [entry, RDF::Vocab::DC.identifier, "urn:bibtex:#{bibtex.key}"]
   end
 
   def keywords
@@ -274,7 +274,7 @@ class BibTeX::Entry::RDFConverter
     remove_from_fallback(:keywords)
 
     bibtex[:keywords].to_s.split(/\s*[,;]\s*/).each do |keyword|
-      graph << [entry, RDF::DC.subject, keyword]
+      graph << [entry, RDF::Vocab::DC.subject, keyword]
     end
   end
 
@@ -284,14 +284,14 @@ class BibTeX::Entry::RDFConverter
 
     bibtex[:language] = 'german' if bibtex[:language] == 'ngerman'
 
-    graph << [entry, RDF::DC.language, bibtex[:language].to_s]
+    graph << [entry, RDF::Vocab::DC.language, bibtex[:language].to_s]
   end
 
   def location
     return unless bibtex.field?(:location)
     remove_from_fallback(:location)
 
-    graph << [entry, RDF::DC.Location, bibtex[:location].to_s]
+    graph << [entry, RDF::Vocab::DC.Location, bibtex[:location].to_s]
     if [:proceedings, :inproceedings, :conference].include?(bibtex.type)
       event = RDF::Vocabulary.new('http://purl.org/NET/c4dm/event.owl')
       graph << [entry, event[:place], org]
@@ -334,7 +334,7 @@ class BibTeX::Entry::RDFConverter
 
     org = agent(bibtex[:organization].to_s) { create_agent(bibtex[:organization].to_s, :Organization) }
 
-    graph << [entry, RDF::DC.contributor, org]
+    graph << [entry, RDF::Vocab::DC.contributor, org]
     graph << [entry, bibo[:organizer], org] if [:proceedings, :inproceedings, :conference].include?(bibtex.type)
   end
 
@@ -363,7 +363,7 @@ class BibTeX::Entry::RDFConverter
 
     parent_id = RDF::URI.new(bibtex.parent.identifier)
     BibTeX::Entry::RDFConverter.new(bibtex.parent, graph, agent).convert! unless uri_in_graph?(parent_id)
-    graph << [entry, RDF::DC.isPartOf, parent_id]
+    graph << [entry, RDF::Vocab::DC.isPartOf, parent_id]
   end
 
   def publisher
@@ -387,7 +387,7 @@ class BibTeX::Entry::RDFConverter
       graph << [org, address[:localityName], bibtex[:address]]
     end
 
-    graph << [entry, RDF::DC.publisher, org]
+    graph << [entry, RDF::Vocab::DC.publisher, org]
     graph << [entry, bibo[:publisher], org]
   end
 
@@ -397,7 +397,7 @@ class BibTeX::Entry::RDFConverter
 
     org = agent(bibtex[:school].to_s) { create_agent(bibtex[:school].to_s, :Organization) }
 
-    graph << [entry, RDF::DC.contributor, org]
+    graph << [entry, RDF::Vocab::DC.contributor, org]
   end
 
   def series
@@ -409,9 +409,9 @@ class BibTeX::Entry::RDFConverter
 
     series = RDF::Node.new
     graph << [series, RDF.type, bibo[:MultiVolumeBook]]
-    graph << [series, RDF::DC.title, bibtex[:series].to_s]
+    graph << [series, RDF::Vocab::DC.title, bibtex[:series].to_s]
 
-    graph << [entry, RDF::DC.isPartOf, series]
+    graph << [entry, RDF::Vocab::DC.isPartOf, series]
   end
 
   def thesis_degree
@@ -449,7 +449,7 @@ class BibTeX::Entry::RDFConverter
     title = [bibtex[:title].to_s, bibtex[:subtitle].to_s]
       .reject { |t| t.nil? || t.empty? }
       .join(': ')
-    graph << [entry, RDF::DC.title, title]
+    graph << [entry, RDF::Vocab::DC.title, title]
     graph << [entry, bibo[:shortTitle], bibtex[:title].to_s] if bibtex.field?(:subtitle)
   end
 
@@ -461,7 +461,7 @@ class BibTeX::Entry::RDFConverter
       create_agent(bibtex[:translator].to_s, :Person)
     end
 
-    graph << [entry, RDF::DC.contributor, node]
+    graph << [entry, RDF::Vocab::DC.contributor, node]
     graph << [entry, bibo[:translator], node]
   end
 
@@ -470,9 +470,9 @@ class BibTeX::Entry::RDFConverter
 
     case bibtex.type
     when :proceedings, :journal
-      graph << [entry, RDF::DC.type, 'Collection']
+      graph << [entry, RDF::Vocab::DC.type, 'Collection']
     else
-      graph << [entry, RDF::DC.type, 'Text']
+      graph << [entry, RDF::Vocab::DC.type, 'Text']
     end
   end
 
@@ -480,7 +480,7 @@ class BibTeX::Entry::RDFConverter
     return unless bibtex.field?(:url)
     remove_from_fallback(:url)
 
-    graph << [entry, RDF::DC.URI, bibtex[:url].to_s]
+    graph << [entry, RDF::Vocab::DC.URI, bibtex[:url].to_s]
     graph << [entry, bibo[:uri], bibtex[:url].to_s]
   end
 
@@ -509,7 +509,7 @@ class BibTeX::Entry::RDFConverter
     end
     date = month.nil? ? year : [year, month].join('-')
 
-    graph << [entry, RDF::DC.issued, date]
+    graph << [entry, RDF::Vocab::DC.issued, date]
   end
 
   protected
@@ -542,8 +542,8 @@ class BibTeX::Entry::RDFConverter
   def create_agent(name, type)
     node = RDF::Node.new
 
-    graph << [node, RDF.type, RDF::FOAF[type]]
-    graph << [node, RDF::FOAF.name, name.to_s]
+    graph << [node, RDF.type, RDF::Vocab::FOAF[type]]
+    graph << [node, RDF::Vocab::FOAF.name, name.to_s]
 
     if name.is_a?(BibTeX::Name)
       [:given, :family, :prefix, :suffix].each do |part|


### PR DESCRIPTION
The new version of rdf gem contains breaking changes. It has, for instance, moved rdf vocabularies to a new gem called rdf-vocab. The changes applied here make bibtex-ruby compatible with the new version of rdf.