### PR TITLE
Updated URI detection when parsing bibtex

### DIFF
--- a/lib/bibtex/utilities.rb
+++ b/lib/bibtex/utilities.rb
@@ -33,7 +33,7 @@ module BibTeX
       case
       when string.length < 260 && File.exist?(string)
         Bibliography.open(string, options, &block)
-      when string =~ /^[a-z]+:\/\//i
+      when string =~ /\A[a-z]+:\/\//i
         Bibliography.open(string, options)
       else
         Bibliography.parse(string, options)


### PR DESCRIPTION
\A should be the start of the string which sounds more appropriate for URI detection than ^ which is the start of the line.

Of course, there shouldn't be a URI at the start of the line in bibtex anyway so even with this change the most likely outcome is a slightly different error but it should be an accurate error.