### PR TITLE
append a linebreak when serializing non-entry elements

### DIFF
--- a/lib/bibtex/elements.rb
+++ b/lib/bibtex/elements.rb
@@ -294,7 +294,7 @@ module BibTeX
 
     # Returns a string representation of the @string object.
     def to_s(options = {})
-      "@string{ #{content} }"
+      "@string{ #{content} }\n"
     end
 
     def to_hash(options = {})
@@ -338,7 +338,7 @@ module BibTeX
 
     # Returns a string representation of the @preamble object
     def to_s(options = {})
-      "@preamble{ #{content} }"
+      "@preamble{ #{content} }\n"
     end
   end
 
@@ -351,7 +351,7 @@ module BibTeX
     end
 
     def to_s(options = {})
-      "@comment{ #@content }"
+      "@comment{ #@content }\n"
     end
   end
 

--- a/test/bibtex/test_elements.rb
+++ b/test/bibtex/test_elements.rb
@@ -45,9 +45,9 @@ module BibTeX
       end
 
       it 'should support round-trips of all parsed preambles' do
-        assert_equal %q[@preamble{ "This bibliography was created \today" }], @preambles[0].to_s
-        assert_equal %q[@preamble{ "Bib\TeX" }], @preambles[1].to_s
-        assert_equal %q[@preamble{ "Maintained by " # maintainer }], @preambles[2].to_s
+        assert_equal %[@preamble{ "This bibliography was created \\today" }\n], @preambles[0].to_s
+        assert_equal %[@preamble{ "Bib\\TeX" }\n], @preambles[1].to_s
+        assert_equal %[@preamble{ "Maintained by " # maintainer }\n], @preambles[2].to_s
       end
 
       it 'should support string replacement of preamble contents' do


### PR DESCRIPTION
Hi,

With current implementation, when we parse and serialize a bib
```
@string{ foo = "Foo" }
@string{ bar = "Bar" }
```
then the following is obtained.
```
@string{ foo = "Foo" }@string{ bar = "Bar" }
```

I suppose this behaviour is undesirable for most people.