### PR TITLE
Avoid issue with option hash removing :filter.

### DIFF
--- a/lib/bibtex/value.rb
+++ b/lib/bibtex/value.rb
@@ -180,16 +180,10 @@ module BibTeX
     # If the option :filter is given, the Value will be converted using
     # the filter(s) specified.
     def to_s(options = {})
-      opts = options.clone
-      if opts.key?(:filter) and opts.key?(:quotes)
-        if !atomic? || symbol?
-          opts.delete(:quotes)
-        end
-        return convert(opts.delete(:filter)).to_s(opts)
-      end
-      return value.to_s unless opts.key?(:quotes) && atomic? && !symbol?
+      return convert(options[:filter]).to_s(options.reject { |k,| k == :filter || (k == :quotes && (!atomic? || symbol?)) }) if options.key?(:filter)
+      return value.to_s unless options.key?(:quotes) && atomic? && !symbol?
 
-      q = Array(opts[:quotes])
+      q = Array(options[:quotes])
       [q[0], value, q[-1]].compact.join
     end
 

--- a/lib/bibtex/value.rb
+++ b/lib/bibtex/value.rb
@@ -180,10 +180,11 @@ module BibTeX
     # If the option :filter is given, the Value will be converted using
     # the filter(s) specified.
     def to_s(options = {})
-      return convert(options.delete(:filter)).to_s(options) if options.key?(:filter)
-      return value.to_s unless options.key?(:quotes) && atomic? && !symbol?
+      opts = options.clone
+      return convert(opts.delete(:filter)).to_s(opts) if opts.key?(:filter)
+      return value.to_s unless opts.key?(:quotes) && atomic? && !symbol?
 
-      q = Array(options[:quotes])
+      q = Array(opts[:quotes])
       [q[0], value, q[-1]].compact.join
     end
 

--- a/lib/bibtex/value.rb
+++ b/lib/bibtex/value.rb
@@ -181,7 +181,12 @@ module BibTeX
     # the filter(s) specified.
     def to_s(options = {})
       opts = options.clone
-      return convert(opts.delete(:filter)).to_s(opts) if opts.key?(:filter)
+      if opts.key?(:filter) and opts.key?(:quotes)
+        if !atomic? || symbol?
+          opts.delete(:quotes)
+        end
+        return convert(opts.delete(:filter)).to_s(opts)
+      end
       return value.to_s unless opts.key?(:quotes) && atomic? && !symbol?
 
       q = Array(opts[:quotes])

--- a/test/bibtex/test_entry.rb
+++ b/test/bibtex/test_entry.rb
@@ -483,6 +483,27 @@ module BibTeX
       end
     end
 
+    describe '#to_s' do
+      before do
+        @bib = Bibliography.parse(<<-BIBINPUT, { :parse_months => false })
+          @misc{foo,
+            title  = {A
+                       title},
+            series = {A
+                       series},
+            month  = dec
+          }
+          BIBINPUT
+      end
+      it 'applies filters when converting to strings' do
+        assert_equal "@misc{foo,\n"\
+                     "  title = {A title},\n"\
+                     "  series = {A series},\n"\
+                     "  month = dec\n"\
+                     "}\n", @bib['foo'].to_s({ filter: :linebreaks })
+      end
+    end
+
     def test_simple
       bib = BibTeX::Bibliography.open(Test.fixtures(:entry), debug: false)
       refute_nil(bib)


### PR DESCRIPTION
I'm working on a small feature for jekyll-scholar which relies on `to_s` for `Entry` being passed a `:filter` symbol through the `options` array. I noticed that the filter is only being applied to the first field in each entry, which I believe is due to the `options.delete` killing this on the first value being processed.