### PR TITLE
Support Ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ cache: bundler
 
 matrix:
   include:
-  - rvm: 2.7
+  - rvm: 3.0
     env: WITH_COVERALLS=true
+  - rvm: 2.7
+    env: WITH_COVERALLS=false
   - rvm: 2.6
     env: WITH_COVERALLS=false
   - rvm: 2.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     bibtex-ruby (5.1.6)
       latex-decode (~> 0.0)
+      rexml (~> 3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -87,6 +88,7 @@ GEM
     redcarpet (3.5.0)
     rest-client (1.6.7)
       mime-types (>= 1.16)
+    rexml (3.2.4)
     ruby-prof (1.4.1)
     simplecov (0.19.0)
       docile (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bibtex-ruby (5.1.4)
+    bibtex-ruby (5.1.6)
       latex-decode (~> 0.0)
 
 GEM

--- a/bibtex-ruby.gemspec
+++ b/bibtex-ruby.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   END_DESCRIPTION
 
   s.add_runtime_dependency('latex-decode', ['~>0.0'])
+  s.add_runtime_dependency('rexml', ['~>3.0'])
 
   s.files        = File.open('Manifest').readlines.map(&:chomp)
   s.test_files   = Dir.glob('test/**/test*.rb')


### PR DESCRIPTION
This pull request adds compatibility with Ruby 3.0, which has been released recently.

The only important change is that REXML has been specified as a runtime dependency. This is necessary because REXML is now a bundled gem (see https://stdgems.org/). Version constraint for this gem (`~> 3.0`) is relaxed enough to support REXML provided in Ruby 2.6 and 2.7.