### PR TITLE
Change License of gem from GPL 3.0 to dual-license GPL 3.0 and BSD-2-Clause

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,5 @@
+* Dual-license bibtex-ruby under GPL-3.0 and BSD-2-Clause
+
 6.0.0 / 2021-01-07
 ==================
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,19 @@
+Dual-Licensed under GPL-3.0 and BSD-2-Clause
+
+---
+
+Copyright 2010 Sylvester Keil
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---
+
 GNU GENERAL PUBLIC LICENSE
 Version 3, 29 June 2007
 

--- a/README.md
+++ b/README.md
@@ -609,5 +609,5 @@ Copyright 2011-2015 [Sylvester Keil](http://sylvester.keil.or.at/).
 Kudos to all [contributors](https://github.com/inukshuk/bibtex-ruby/contributors)
 who have made BibTeX-Ruby possible.
 
-This software is distributed under the terms and conditions of the GNU GPL.
+This software is dual-licensed under GPL-3.0 and BSD-2-Clause.
 See LICENSE for details.

--- a/bibtex-ruby.gemspec
+++ b/bibtex-ruby.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.authors     = ['Sylvester Keil']
   s.email       = ['sylvester@keil.or.at']
   s.homepage    = 'http://inukshuk.github.com/bibtex-ruby'
-  s.license     = 'GPL-3.0'
+  s.licenses     = ['GPL-3.0', 'BSD-2-Clause']
 
   s.summary     = 'A BibTeX parser, converter and API for Ruby.'
   s.description = <<-END_DESCRIPTION.gsub(/^\s+/, '')

--- a/lib/bibtex.rb
+++ b/lib/bibtex.rb
@@ -32,8 +32,8 @@ require 'bibtex/version'
 # +Preamble+, +Comment+, and +Entry+.
 #
 # Author:: {Sylvester Keil}[http://sylvester.keil.or.at]
-# Copyright:: Copyright (c) 2010-2014 Sylvester Keil
-# License:: GNU GPL 3.0
+# Copyright:: Copyright (c) 2010-2022 Sylvester Keil
+# License: GNU GPL 3.0 and BSD-2-Clause
 #
 module BibTeX
   #


### PR DESCRIPTION
Currently, the gem is only available under the terms and conditions of GPL 3.0.

This is quite restrictive, as one could not use the gem within a proprietary software.

This is why **I am proposing to dual-license the gem** under [GPL 3.0](https://opensource.org/licenses/GPL-3.0) AND [BSD-2-Clause](https://opensource.org/licenses/BSD-2-Clause)

**For this to happen, every past contributor must accept this license change.**

I would like to ask every contributor to state their support for this license change in this Pull Request. Simply post "I consent to the license change proposed"

## Consent tracker

- [ ] @inukshuk
- [ ] @tmaier 
- [ ] @ktns 
- [ ] @grafi-tt 
- [ ] @etc 
- [ ] @mapreal19 
- [ ] @cruessler 
- [ ] @andriusvelykis 
- [ ] @RubenVerborgh 
- [ ] @jamesprior 
- [ ] @mdave 
- [ ] @sharnik 
- [ ] @casutton 
- [ ] @teoric 
- [ ] @plessl 
- [ ] @houshuang 
- [ ] @mfenner 
- [ ] @skalee 
- [ ] @steffengodskesen 
- [ ] @retrography 
- [ ] @temporaer 
- [ ] @frau-sma 